### PR TITLE
Make README.md examples fit typical style

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@ Some funny things for OpenVoiceOS, mostly quotes from movies
 
 ## Examples
 
-- "current stardate"
-- "open the pod bay doors"
-- "first law of robotics"
-- "how to play rock_paper_scissors_lizard_spock"
-- "how many languages do you speak"
-- "do you like portal"
-- "what would duke nukem say"
-- "what would HAL 9000 say"
-- "what would arnold say"
-- "what would glados say"
-- "what would bender say"
+- "Current stardate?"
+- "Open the pod bay doors."
+- "First law of robotics?"
+- "How to play rock paper scissors lizard spock?"
+- "How many languages do you speak?"
+- "Do you like Portal?"
+- "What would Duke Nukem say?"
+- "What would HAL 9000 say?"
+- "What would Arnold say?"
+- "What would GLaDOS say?"
+- "What would Bender say?"
 
 ## Grandma Mode
 


### PR DESCRIPTION
The prior copy looked out of place in the rest of the homescreen examples, which are all capitalized and end in punctuation.