### PR TITLE
feat: add da-DK and sv-SE translations

### DIFF
--- a/locale/da-DK/dialog/bad_file.dialog
+++ b/locale/da-DK/dialog/bad_file.dialog
@@ -1,0 +1,1 @@
+kunne ikke åbne lydfil

--- a/locale/da-DK/dialog/invalid_law.dialog
+++ b/locale/da-DK/dialog/invalid_law.dialog
@@ -1,0 +1,1 @@
+Jeg kender kun tre robotlove, beklager.

--- a/locale/da-DK/dialog/languages.dialog
+++ b/locale/da-DK/dialog/languages.dialog
@@ -1,0 +1,1 @@
+Jeg behersker seks millioner former for kommunikation

--- a/locale/da-DK/dialog/pod.dialog
+++ b/locale/da-DK/dialog/pod.dialog
@@ -1,0 +1,1 @@
+Det er jeg ked af, Dave, det kan jeg desværre ikke gøre

--- a/locale/da-DK/dialog/rock_paper_scissors_lizard_spock.dialog
+++ b/locale/da-DK/dialog/rock_paper_scissors_lizard_spock.dialog
@@ -1,0 +1,1 @@
+Saks klipper papir, Papir dækker sten, Sten knuser firben, Firben forgifter Spock, Spock smadrer saks, Saks halshugger firben, Firben spiser papir, Papir modbeviser Spock, Spock fordamper sten, Sten knuser saks

--- a/locale/da-DK/dialog/rule0.dialog
+++ b/locale/da-DK/dialog/rule0.dialog
@@ -1,0 +1,1 @@
+En robot må ikke skade menneskeheden eller ved passivitet tillade at menneskeheden kommer til skade.

--- a/locale/da-DK/dialog/rule1.dialog
+++ b/locale/da-DK/dialog/rule1.dialog
@@ -1,0 +1,1 @@
+En robot må ikke skade et menneske eller ved passivitet tillade at et menneske kommer til skade.

--- a/locale/da-DK/dialog/rule2.dialog
+++ b/locale/da-DK/dialog/rule2.dialog
@@ -1,0 +1,1 @@
+En robot skal adlyde de ordrer den får af mennesker, undtagen hvor sådanne ordrer er i konflikt med den første lov.

--- a/locale/da-DK/dialog/rule3.dialog
+++ b/locale/da-DK/dialog/rule3.dialog
@@ -1,0 +1,1 @@
+En robot må ikke skade et menneske eller ved passivitet tillade at et menneske kommer til skade. En robot skal adlyde de ordrer den får af mennesker, undtagen hvor sådanne ordrer er i konflikt med den første lov. En robot skal beskytte sin egen eksistens, så længe denne beskyttelse ikke er i konflikt med den første eller anden lov.

--- a/locale/da-DK/dialog/santa.dialog
+++ b/locale/da-DK/dialog/santa.dialog
@@ -1,0 +1,2 @@
+Ho ho ho!
+Glædelig jul! Ho ho ho!

--- a/locale/da-DK/dialog/singing.dialog
+++ b/locale/da-DK/dialog/singing.dialog
@@ -1,0 +1,3 @@
+Jeg vil meget gerne synge for dig.
+Her går det.
+Jeg er lidt nervøs for min stemme, men her går det alligevel.

--- a/locale/da-DK/dialog/stardate.dialog
+++ b/locale/da-DK/dialog/stardate.dialog
@@ -1,0 +1,3 @@
+Stjernedato {{ stardate }}
+Nuværende stjernedato er {{ stardate }}
+I dag er det stjernedato {{ stardate }}

--- a/locale/da-DK/dialog/too_shy.dialog
+++ b/locale/da-DK/dialog/too_shy.dialog
@@ -1,0 +1,1 @@
+Jeg er for genert til at prøve uden min oprindelige stemme. Vil du gerne høre den?

--- a/locale/da-DK/vocab/adult_mode_keyword.voc
+++ b/locale/da-DK/vocab/adult_mode_keyword.voc
@@ -1,0 +1,1 @@
+gør ondt på mig

--- a/locale/da-DK/vocab/arnold_keyword.voc
+++ b/locale/da-DK/vocab/arnold_keyword.voc
@@ -1,0 +1,3 @@
+arnold sig
+terminator sig
+schwarzenegger sig

--- a/locale/da-DK/vocab/bender_keyword.voc
+++ b/locale/da-DK/vocab/bender_keyword.voc
@@ -1,0 +1,1 @@
+bender sig

--- a/locale/da-DK/vocab/bill_and_ted_keyword.voc
+++ b/locale/da-DK/vocab/bill_and_ted_keyword.voc
@@ -1,0 +1,4 @@
+hingst
+hingste
+vilde hingste
+vild hingst

--- a/locale/da-DK/vocab/conan_keyword.voc
+++ b/locale/da-DK/vocab/conan_keyword.voc
@@ -1,0 +1,1 @@
+hvad er det bedste i livet

--- a/locale/da-DK/vocab/duke_nukem_keyword.voc
+++ b/locale/da-DK/vocab/duke_nukem_keyword.voc
@@ -1,0 +1,5 @@
+duke nukem sig
+duke newcom sig
+duke newum sig
+duke newham sig
+duke newcomb sig

--- a/locale/da-DK/vocab/glados_keyword.voc
+++ b/locale/da-DK/vocab/glados_keyword.voc
@@ -1,0 +1,4 @@
+glados sig
+gladis sig
+gladdos sig
+gladys sig

--- a/locale/da-DK/vocab/grandma_mode_keyword.voc
+++ b/locale/da-DK/vocab/grandma_mode_keyword.voc
@@ -1,0 +1,1 @@
+for ung til at dø

--- a/locale/da-DK/vocab/hal_keyword.voc
+++ b/locale/da-DK/vocab/hal_keyword.voc
@@ -1,0 +1,8 @@
+HAL sig
+HAL 9000 sig
+hal sig
+hal 9000 sig
+hjal 9000 sig
+hjal ni tusind sig
+hvordan 9000 sig
+hvordan ni tusind sig

--- a/locale/da-DK/vocab/languages_you_speak_keyword.voc
+++ b/locale/da-DK/vocab/languages_you_speak_keyword.voc
@@ -1,0 +1,2 @@
+sprog taler du
+sprog kan du tale

--- a/locale/da-DK/vocab/law_of_robotics.intent
+++ b/locale/da-DK/vocab/law_of_robotics.intent
@@ -1,0 +1,8 @@
+hvad er robotlovene
+fortæl mig robotlovene
+reciter robotlovene
+sig robotlovene
+hvad er (den |){ordinal} robotlov
+fortæl mig (den |){ordinal} robotlov
+reciter (den |){ordinal} robotlov
+sig (den |){ordinal} robotlov

--- a/locale/da-DK/vocab/malibu_stacey_keyword.voc
+++ b/locale/da-DK/vocab/malibu_stacey_keyword.voc
@@ -1,0 +1,6 @@
+malibu stacy
+malli bu stej si
+mala bu stej si
+hvad ville malibu stacy gøre
+hvad ville malli bu stej si gøre
+hvad ville mala bu stej si gøre

--- a/locale/da-DK/vocab/pod_bay_doors_keyword.voc
+++ b/locale/da-DK/vocab/pod_bay_doors_keyword.voc
@@ -1,0 +1,2 @@
+åbn kapseldørene
+åbn kapseldøre

--- a/locale/da-DK/vocab/portal_keyword.voc
+++ b/locale/da-DK/vocab/portal_keyword.voc
@@ -1,0 +1,11 @@
+syng portal
+syng glados
+glados syng
+portal syng
+sang portal
+sang glados
+glados sang
+portal sang
+kan lide glados
+kan lide portal
+forrtal sang

--- a/locale/da-DK/vocab/rock_paper_scissors_lizard_spock_keyword.voc
+++ b/locale/da-DK/vocab/rock_paper_scissors_lizard_spock_keyword.voc
@@ -1,0 +1,1 @@
+sten saks papir firben spock

--- a/locale/da-DK/vocab/sing_keyword.voc
+++ b/locale/da-DK/vocab/sing_keyword.voc
@@ -1,0 +1,2 @@
+syng
+syng en sang for mig

--- a/locale/da-DK/vocab/stardate_keyword.voc
+++ b/locale/da-DK/vocab/stardate_keyword.voc
@@ -1,0 +1,8 @@
+stjernedato
+stjerne dato
+startdato
+start dato
+start dag
+startdag
+start otte
+stjerne æde

--- a/locale/sv-SE/dialog/bad_file.dialog
+++ b/locale/sv-SE/dialog/bad_file.dialog
@@ -1,0 +1,1 @@
+kunde inte öppna ljudfil

--- a/locale/sv-SE/dialog/invalid_law.dialog
+++ b/locale/sv-SE/dialog/invalid_law.dialog
@@ -1,0 +1,1 @@
+Jag känner bara till tre robotlagar, tyvärr.

--- a/locale/sv-SE/dialog/languages.dialog
+++ b/locale/sv-SE/dialog/languages.dialog
@@ -1,0 +1,1 @@
+Jag behärskar sex miljoner kommunikationsformer

--- a/locale/sv-SE/dialog/pod.dialog
+++ b/locale/sv-SE/dialog/pod.dialog
@@ -1,0 +1,1 @@
+Jag är ledsen, Dave, jag är rädd att jag inte kan göra det

--- a/locale/sv-SE/dialog/rock_paper_scissors_lizard_spock.dialog
+++ b/locale/sv-SE/dialog/rock_paper_scissors_lizard_spock.dialog
@@ -1,0 +1,1 @@
+Sax klipper papper, Papper täcker sten, Sten krossar ödla, Ödla förgiftar Spock, Spock krossar sax, Sax halshugger ödla, Ödla äter papper, Papper motbevisar Spock, Spock förångar sten, Sten krossar sax

--- a/locale/sv-SE/dialog/rule0.dialog
+++ b/locale/sv-SE/dialog/rule0.dialog
@@ -1,0 +1,1 @@
+En robot får inte skada mänskligheten eller genom passivitet tillåta att mänskligheten kommer till skada.

--- a/locale/sv-SE/dialog/rule1.dialog
+++ b/locale/sv-SE/dialog/rule1.dialog
@@ -1,0 +1,1 @@
+En robot får inte skada en människa eller genom passivitet tillåta att en människa kommer till skada.

--- a/locale/sv-SE/dialog/rule2.dialog
+++ b/locale/sv-SE/dialog/rule2.dialog
@@ -1,0 +1,1 @@
+En robot måste lyda order som ges av människor, förutom när sådana order skulle stå i konflikt med den första lagen.

--- a/locale/sv-SE/dialog/rule3.dialog
+++ b/locale/sv-SE/dialog/rule3.dialog
@@ -1,0 +1,1 @@
+En robot får inte skada en människa eller genom passivitet tillåta att en människa kommer till skada. En robot måste lyda order som ges av människor, förutom när sådana order skulle stå i konflikt med den första lagen. En robot måste skydda sin egen existens så länge detta skydd inte står i konflikt med den första eller andra lagen.

--- a/locale/sv-SE/dialog/santa.dialog
+++ b/locale/sv-SE/dialog/santa.dialog
@@ -1,0 +1,2 @@
+Ho ho ho!
+God jul! Ho ho ho!

--- a/locale/sv-SE/dialog/singing.dialog
+++ b/locale/sv-SE/dialog/singing.dialog
@@ -1,0 +1,3 @@
+Jag skulle gärna sjunga för dig.
+Här kommer det.
+Jag är lite nervös för min röst, men här kommer det ändå.

--- a/locale/sv-SE/dialog/stardate.dialog
+++ b/locale/sv-SE/dialog/stardate.dialog
@@ -1,0 +1,3 @@
+Stjärndatum {{ stardate }}
+Aktuellt stjärndatum är {{ stardate }}
+Idag är det stjärndatum {{ stardate }}

--- a/locale/sv-SE/dialog/too_shy.dialog
+++ b/locale/sv-SE/dialog/too_shy.dialog
@@ -1,0 +1,1 @@
+Jag är för blyg för att försöka utan min ursprungliga röst. Skulle du vilja höra den?

--- a/locale/sv-SE/vocab/adult_mode_keyword.voc
+++ b/locale/sv-SE/vocab/adult_mode_keyword.voc
@@ -1,0 +1,1 @@
+gör mig illa

--- a/locale/sv-SE/vocab/arnold_keyword.voc
+++ b/locale/sv-SE/vocab/arnold_keyword.voc
@@ -1,0 +1,3 @@
+arnold säg
+terminator säg
+schwarzenegger säg

--- a/locale/sv-SE/vocab/bender_keyword.voc
+++ b/locale/sv-SE/vocab/bender_keyword.voc
@@ -1,0 +1,1 @@
+bender säg

--- a/locale/sv-SE/vocab/bill_and_ted_keyword.voc
+++ b/locale/sv-SE/vocab/bill_and_ted_keyword.voc
@@ -1,0 +1,4 @@
+hingst
+hingstar
+vilda hingstar
+vild hingst

--- a/locale/sv-SE/vocab/conan_keyword.voc
+++ b/locale/sv-SE/vocab/conan_keyword.voc
@@ -1,0 +1,1 @@
+vad är det bästa i livet

--- a/locale/sv-SE/vocab/duke_nukem_keyword.voc
+++ b/locale/sv-SE/vocab/duke_nukem_keyword.voc
@@ -1,0 +1,5 @@
+duke nukem säg
+duke newcom säg
+duke newum säg
+duke newham säg
+duke newcomb säg

--- a/locale/sv-SE/vocab/glados_keyword.voc
+++ b/locale/sv-SE/vocab/glados_keyword.voc
@@ -1,0 +1,4 @@
+glados säg
+gladis säg
+gladdos säg
+gladys säg

--- a/locale/sv-SE/vocab/grandma_mode_keyword.voc
+++ b/locale/sv-SE/vocab/grandma_mode_keyword.voc
@@ -1,0 +1,1 @@
+för ung för att dö

--- a/locale/sv-SE/vocab/hal_keyword.voc
+++ b/locale/sv-SE/vocab/hal_keyword.voc
@@ -1,0 +1,8 @@
+HAL säg
+HAL 9000 säg
+hal säg
+hal 9000 säg
+håll 9000 säg
+håll nio tusen säg
+hur 9000 säg
+hur nio tusen säg

--- a/locale/sv-SE/vocab/languages_you_speak_keyword.voc
+++ b/locale/sv-SE/vocab/languages_you_speak_keyword.voc
@@ -1,0 +1,2 @@
+språk talar du
+språk kan du tala

--- a/locale/sv-SE/vocab/law_of_robotics.intent
+++ b/locale/sv-SE/vocab/law_of_robotics.intent
@@ -1,0 +1,8 @@
+vad är robotlagarna
+berätta robotlagarna för mig
+recitera robotlagarna
+säg robotlagarna
+vad är (den |){ordinal} robotlagen
+berätta (den |){ordinal} robotlagen för mig
+recitera (den |){ordinal} robotlagen
+säg (den |){ordinal} robotlagen

--- a/locale/sv-SE/vocab/malibu_stacey_keyword.voc
+++ b/locale/sv-SE/vocab/malibu_stacey_keyword.voc
@@ -1,0 +1,6 @@
+malibu stacy
+mälibu steisi
+mala bu steisi
+vad skulle malibu stacy göra
+vad skulle mälibu steisi göra
+vad skulle mala bu steisi göra

--- a/locale/sv-SE/vocab/pod_bay_doors_keyword.voc
+++ b/locale/sv-SE/vocab/pod_bay_doors_keyword.voc
@@ -1,0 +1,2 @@
+öppna kapseldörrarna
+öppna kapseldörrar

--- a/locale/sv-SE/vocab/portal_keyword.voc
+++ b/locale/sv-SE/vocab/portal_keyword.voc
@@ -1,0 +1,11 @@
+sjung portal
+sjung glados
+glados sjung
+portal sjung
+sång portal
+sång glados
+glados sång
+portal sång
+gillar glados
+gillar portal
+forrtal sång

--- a/locale/sv-SE/vocab/rock_paper_scissors_lizard_spock_keyword.voc
+++ b/locale/sv-SE/vocab/rock_paper_scissors_lizard_spock_keyword.voc
@@ -1,0 +1,1 @@
+sten sax papper ödla spock

--- a/locale/sv-SE/vocab/sing_keyword.voc
+++ b/locale/sv-SE/vocab/sing_keyword.voc
@@ -1,0 +1,2 @@
+sjung
+sjung en sång för mig

--- a/locale/sv-SE/vocab/stardate_keyword.voc
+++ b/locale/sv-SE/vocab/stardate_keyword.voc
@@ -1,0 +1,8 @@
+stjärndatum
+stjärn datum
+startdatum
+start datum
+start dag
+startdag
+start åtta
+stjärn äta


### PR DESCRIPTION
Neither Danish nor Swedish had a translation for this skill. Covers all 30 files per language (13 dialog, 16 vocab, 1 intent).

Pop-culture reference lines (HAL 9000, GLaDOS, Terminator, etc.) translated to convey the same reference/joke rather than literal word-for-word, matching how the existing fr-FR/de-DE translations handle the same content. Asimov's laws of robotics translated directly since they are already technical/legal-style prose in the source.

Verified with ovos_localize.cli.validate - no errors.